### PR TITLE
Change null to empty string to fix parsing error

### DIFF
--- a/src/main/java/swurg/workers/Worker.java
+++ b/src/main/java/swurg/workers/Worker.java
@@ -166,7 +166,7 @@ public class Worker {
           Schema schema = parameter.getSchema();
           String value = Optional.ofNullable(schema)
               .map(Schema::getType)
-              .orElse(null);
+              .orElse("");
 
           if ("header".equals(in))
             httpParameters.add(HttpParameter.cookieParameter(name, value));


### PR DESCRIPTION
Got the error "OpenAPI Parser: Cannot read the array length because "<parameter4>" is null" during import of https://api.elhub.no/energy-data/v0/openapi.json (which is an OpenAPI 3.1 file, but I don't know if that is the cause) and the stack trace hinted at something wrong coming from buildHttpRequestParameters(). Changing from `null` to `""` in the last else-branch made the file load without errors.  I haven't dug further into why `null` fails as it appears to be in internal Burp code.